### PR TITLE
Use Throwable instead of Exception

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
@@ -23,8 +23,9 @@ public abstract class OperationalEventService {
 
     /**
      * Indicates that an item is now being monitored by IIS
-     * @param logger  Logger belonging to the calling class
-     * @param projectId  Git projectId of the monitored item
+     *
+     * @param logger    Logger belonging to the calling class
+     * @param projectId Git projectId of the monitored item
      */
     public void itemMonitoredEvent(Logger logger, int projectId) {
         itemEvent(logger, ItemEventType.ITEM_MONITORED, null, null, projectId);
@@ -32,10 +33,11 @@ public abstract class OperationalEventService {
 
     /**
      * Indicates that an item has been created in the imrt database
-     * @param logger  Logger belonging to the calling class
-     * @param key  Database key for the newly created item
-     * @param id  Itembank Id for the newly created item
-     * @param projectId  Git projectId of the newly created item
+     *
+     * @param logger    Logger belonging to the calling class
+     * @param key       Database key for the newly created item
+     * @param id        Itembank Id for the newly created item
+     * @param projectId Git projectId of the newly created item
      */
     public void itemCreatedEvent(Logger logger, int key, String id, int projectId) {
         itemEvent(logger, ItemEventType.ITEM_CREATED, key, id, projectId);
@@ -43,10 +45,11 @@ public abstract class OperationalEventService {
 
     /**
      * Indicates that an item has been updated in the imrt database
-     * @param logger  Logger belonging to the calling class
-     * @param key  Database key for the updated item
-     * @param id  Itembank Id for the updated item
-     * @param projectId  Git projectId of the updated item
+     *
+     * @param logger    Logger belonging to the calling class
+     * @param key       Database key for the updated item
+     * @param id        Itembank Id for the updated item
+     * @param projectId Git projectId of the updated item
      */
     public void itemUpdatedEvent(Logger logger, int key, String id, int projectId) {
         itemEvent(logger, ItemEventType.ITEM_UPDATED, key, id, projectId);
@@ -55,47 +58,51 @@ public abstract class OperationalEventService {
     /**
      * Implementing classes should generate an appropriate event for monitoring
      * item activities.
-     * @param logger  Logger belonging to the calling class
-     * @param type  Type of the event
-     * @param key  Database key for the updated item
-     * @param id  Itembank Id for the updated item
-     * @param projectId  Git projectId of the updated item
+     *
+     * @param logger    Logger belonging to the calling class
+     * @param type      Type of the event
+     * @param key       Database key for the updated item
+     * @param id        Itembank Id for the updated item
+     * @param projectId Git projectId of the updated item
      */
     protected abstract void itemEvent(Logger logger, ItemEventType type, Integer key, String id, Integer projectId);
 
     /**
      * Indicates a fatal error has occurred during processing
-     * @param logger  Logger belonging to the calling class
-     * @param e  Optional exception that caused the error, may be null
-     * @param format  The format string for the message. Uses the standard slf4j formatting scheme
-     *                of using {} as placeholders for arguments
-     * @param args  A list of arguments, corresponding to the {} placeholders in the format string.
+     *
+     * @param logger Logger belonging to the calling class
+     * @param e      Optional {@link Throwable} that caused the error, may be null
+     * @param format The format string for the message. Uses the standard slf4j formatting scheme
+     *               of using {} as placeholders for arguments
+     * @param args   A list of arguments, corresponding to the {} placeholders in the format string.
      */
-    public void serviceError(Logger logger, Exception e, String format, Object ... args) {
+    public void serviceError(Logger logger, Throwable e, String format, Object... args) {
         serviceEvent(logger, ServiceEventType.SERVICE_ERROR, e, format, args);
     }
 
     /**
      * Indicates an unexpected problem has occurred during processing
-     * @param logger  Logger belonging to the calling class
-     * @param e  Optional exception that caused the warning, may be null
-     * @param format  The format string for the message. Uses the standard slf4j formatting scheme
-     *                of using {} as placeholders for arguments
-     * @param args  A list of arguments, corresponding to the {} placeholders in the format string.
+     *
+     * @param logger Logger belonging to the calling class
+     * @param e      Optional {@link Throwable} that caused the warning, may be null
+     * @param format The format string for the message. Uses the standard slf4j formatting scheme
+     *               of using {} as placeholders for arguments
+     * @param args   A list of arguments, corresponding to the {} placeholders in the format string.
      */
-    public void serviceWarning(Logger logger, Exception e, String format, Object ... args) {
+    public void serviceWarning(Logger logger, Throwable e, String format, Object... args) {
         serviceEvent(logger, ServiceEventType.SERVICE_WARNING, e, format, args);
     }
 
     /**
      * Implementing classes should generate an appropriate event for monitoring
      * operational events generated by the application
-     * @param logger  Logger belonging to the calling class
-     * @param type  Type of the event
-     * @param e  Optional exception that caused the warning, may be null
-     * @param format  The format string for the message. Uses the standard slf4j formatting scheme
-     *                of using {} as placeholders for arguments
-     * @param args  A list of arguments, corresponding to the {} placeholders in the format string.
+     *
+     * @param logger Logger belonging to the calling class
+     * @param type   Type of the event
+     * @param e      Optional {@link Throwable} that caused the warning, may be null
+     * @param format The format string for the message. Uses the standard slf4j formatting scheme
+     *               of using {} as placeholders for arguments
+     * @param args   A list of arguments, corresponding to the {} placeholders in the format string.
      */
-    protected abstract void serviceEvent(Logger logger, ServiceEventType type, Exception e, String format, Object ... args);
+    protected abstract void serviceEvent(Logger logger, ServiceEventType type, Throwable e, String format, Object... args);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImpl.java
@@ -27,20 +27,21 @@ public class OperationalEventServiceLoggerImpl extends OperationalEventService {
     /**
      * Appends a message to a string builder and corresponding value to an argument list,
      * only if the value is non-null
-     * @param args  Existing list of arguments to append to
-     * @param builder  Existing string builder to append to
-     * @param message  Message to append, if value is non-null
-     * @param value  Value to append, if it is non-null
+     *
+     * @param args    Existing list of arguments to append to
+     * @param builder Existing string builder to append to
+     * @param message Message to append, if value is non-null
+     * @param value   Value to append, if it is non-null
      */
-    private void append(List<Object> args, StringBuilder builder, String message, Object value){
-        if(value != null) {
+    private void append(List<Object> args, StringBuilder builder, String message, Object value) {
+        if (value != null) {
             builder.append(message);
             args.add(value);
         }
     }
 
     @Override
-    public void serviceEvent(Logger logger, ServiceEventType type, Exception e, String format, Object... args) {
+    public void serviceEvent(Logger logger, ServiceEventType type, Throwable e, String format, Object... args) {
         String output = type + ": " + format;
         List<Object> allArgs = new ArrayList<>(Arrays.asList(args));
         allArgs.add(e);


### PR DESCRIPTION
Use Throwable instead of Exception since Throwable is the base class.  This allows more flexibility and a lot of the Spring API's work against Throwable not Exception.