### PR TITLE
There are iat items that have blank workflow statuses.

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -46,7 +46,6 @@ public abstract class BaseItem extends BaseEntity {
 
     private String grade = StringUtils.EMPTY;
 
-    @NotBlank
     private String workflowStatus;
 
     @NotBlank


### PR DESCRIPTION
There are items in the dev database that do not have a populated workflow status.  This could be invalid but I assumed we could still ingest it rather than throwing.