### PR TITLE
IMRT-366: Feature/handle delete item

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepository.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepository.java
@@ -6,4 +6,20 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StimulusLinkRepository extends JpaRepository<StimulusLink, Integer> {
+    /**
+     * Delete the item -> stimulus asosciation for all {@link org.opentestsystem.ap.imrt.common.model.ImrtItem}s that
+     * are associated to a particular {@link org.opentestsystem.ap.imrt.common.model.Stimulus} that has been deleted.
+     * 
+     * @param itemKeyForStim The key of the {@link org.opentestsystem.ap.imrt.common.model.Stimulus} that has been
+     *                       deleted
+     */
+    void deleteAllByStimulusKey(final Integer itemKeyForStim);
+
+    /**
+     * Delete the item -> stimulus association for an {@link org.opentestsystem.ap.imrt.common.model.ImrtItem}.
+     *
+     * @param itemKey The key of the {@link org.opentestsystem.ap.imrt.common.model.ImrtItem} that should no longer be
+     *                associated to a {@link org.opentestsystem.ap.imrt.common.model.Stimulus}
+     */
+    void deleteByItemKey(final Integer itemKey);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepository.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepository.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StimulusLinkRepository extends JpaRepository<StimulusLink, Integer> {
     /**
-     * Delete the item -> stimulus asosciation for all {@link org.opentestsystem.ap.imrt.common.model.ImrtItem}s that
+     * Delete the item -> stimulus association for all {@link org.opentestsystem.ap.imrt.common.model.ImrtItem}s that
      * are associated to a particular {@link org.opentestsystem.ap.imrt.common.model.Stimulus} that has been deleted.
-     * 
+     *
      * @param itemKeyForStim The key of the {@link org.opentestsystem.ap.imrt.common.model.Stimulus} that has been
      *                       deleted
      */

--- a/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
@@ -11,7 +11,7 @@ public abstract class OperationalEventService {
      * Item related events
      */
     protected enum ItemEventType {
-        ITEM_MONITORED, ITEM_CREATED, ITEM_UPDATED
+        ITEM_MONITORED, ITEM_CREATED, ITEM_UPDATED, ITEM_DELETED
     }
 
     /**
@@ -53,6 +53,18 @@ public abstract class OperationalEventService {
      */
     public void itemUpdatedEvent(Logger logger, int key, String id, int projectId) {
         itemEvent(logger, ItemEventType.ITEM_UPDATED, key, id, projectId);
+    }
+
+    /**
+     * Indicates that an item has been deleted from the imrt database
+     *
+     * @param logger    Logger belonging to the calling class
+     * @param key       Database key for the updated item
+     * @param id        Itembank Id for the updated item
+     * @param projectId Git projectId of the updated item
+     */
+    public void itemDeletedEvent(Logger logger, int key, String id, int projectId) {
+        itemEvent(logger, ItemEventType.ITEM_DELETED, key, id, projectId);
     }
 
     /**

--- a/src/test/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/repository/StimulusLinkRepositoryTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -58,5 +60,47 @@ public class StimulusLinkRepositoryTest {
         stimulusLinkRepository.delete(link);
         // There should be no rows in the DB after the delete
         assertThat(stimulusLinkRepository.findAll().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDeleteAStimulusLinkForASingleItem() {
+        ImrtItem anotherItem = new ImrtItemBuilder()
+                .withKey(3)
+                .withId("789")
+                .build();
+        anotherItem = imrtItemRepository.save(anotherItem);
+
+        final StimulusLink firstStimLink = new StimulusLink(imrtItem, stimulus, "me");
+        final StimulusLink secondStimLink = new StimulusLink(anotherItem, stimulus, "me too");
+
+        stimulusLinkRepository.save(Arrays.asList(firstStimLink, secondStimLink));
+
+        assertThat(stimulusLinkRepository.findAll()).hasSize(2);
+
+        stimulusLinkRepository.deleteByItemKey(anotherItem.getKey());
+
+        assertThat(stimulusLinkRepository.findAll()).hasSize(1);
+        final StimulusLink remainingStimLink = stimulusLinkRepository.findAll().get(0);
+        assertThat(remainingStimLink.getItem()).isEqualToComparingFieldByFieldRecursively(imrtItem);
+    }
+
+    @Test
+    public void shouldDeleteAllStimulusLinksWhenAStimulusItemIsDeleted() {
+        ImrtItem anotherItem = new ImrtItemBuilder()
+                .withKey(3)
+                .withId("789")
+                .build();
+        anotherItem = imrtItemRepository.save(anotherItem);
+
+        final StimulusLink firstStimLink = new StimulusLink(imrtItem, stimulus, "me");
+        final StimulusLink secondStimLink = new StimulusLink(anotherItem, stimulus, "me too");
+
+        stimulusLinkRepository.save(Arrays.asList(firstStimLink, secondStimLink));
+
+        assertThat(stimulusLinkRepository.findAll()).hasSize(2);
+
+        stimulusLinkRepository.deleteAllByStimulusKey(stimulus.getKey());
+
+        assertThat(stimulusLinkRepository.findAll()).hasSize(0);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImplTest.java
@@ -19,6 +19,7 @@ public class OperationalEventServiceLoggerImplTest {
         operationalEventService.itemCreatedEvent(logger, 1, "dev/2", 3);
         operationalEventService.itemMonitoredEvent(logger, 55);
         operationalEventService.itemUpdatedEvent(logger, 4,"dev/5", 6);
+        operationalEventService.itemDeletedEvent(logger, 42, "dev/13", 14);
 
         operationalEventService.serviceError(logger, null, "Test format {} {}", 1, 2);
         operationalEventService.serviceError(logger, new RuntimeException(), "test format {}", 3);


### PR DESCRIPTION
[IMRT-366](https://jira.fairwaytech.com/browse/IMRT-366):  Add methods to facilitate deleting from the `stim_link` table based on what's being deleted (either the `Item` or the `Stimulus`):

* If an `Item` is being deleted, then delete one `stim_link` record for that particular item
* If a `Stimulus` is being deleted, then delete all `stim_link` records that represent that `Stimulus`  