### PR TITLE
IMRT-383: Feature/log query times

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
@@ -33,7 +33,7 @@ public class LoggingAspectConfiguration {
 
     /**
      * Define a point cut for any class that is annotated with a {@link org.springframework.web.bind.annotation.RestController}
-     *  * annotation.
+     * * annotation.
      */
     @Pointcut("within(@org.springframework.web.bind.annotation.RestController * )")
     public void springRestControllers() {
@@ -41,9 +41,15 @@ public class LoggingAspectConfiguration {
 
     /**
      * Define a point cut for any method in the annotated class
+     * <p>
+     * Even though this {@link org.aspectj.lang.annotation.Pointcut} doesn't have the {@code public} keyword on it,
+     * this pattern seems to be correct for only logging pulic methods on a class annotated with the
+     * {@link org.springframework.web.bind.annotation.RestController}.  When used in conjunction with the
+     * {@code springRestControllers()} method, only public methods on the controllers are logged.
+     * </p>
      */
-    @Pointcut("execution(* *.*(..))")
-    protected void allMethods() {
+    @Pointcut("execution(* *(..))")
+    protected void allPublicMethods() {
     }
 
     /**
@@ -55,14 +61,14 @@ public class LoggingAspectConfiguration {
      * @return The result of the method call
      * @throws java.lang.Throwable whenever an exception is encountered during the method call
      */
-    @Around("springRestControllers() && allMethods()")
+    @Around("springRestControllers() && allPublicMethods()")
     public Object logAround(final ProceedingJoinPoint joinPoint) throws Throwable {
         final long startTimeInMs = System.currentTimeMillis();
 
         final Object result = joinPoint.proceed();
 
         operationalEventService.serviceInfo(logger,
-                "Method signature: {}, input args: {}, elapsed time (in ms): {}",
+                "PERFORMANCE: Method signature: {}, input args: {}, elapsed time (in ms): {}",
                 joinPoint.getSignature().toShortString(),
                 joinPoint.getArgs(),
                 System.currentTimeMillis() - startTimeInMs);

--- a/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
@@ -31,10 +31,17 @@ public class LoggingAspectConfiguration {
         this.operationalEventService = operationalEventService;
     }
 
+    /**
+     * Define a point cut for any class that is annotated with a {@link org.springframework.web.bind.annotation.RestController}
+     *  * annotation.
+     */
     @Pointcut("within(@org.springframework.web.bind.annotation.RestController * )")
     public void springRestControllers() {
     }
 
+    /**
+     * Define a point cut for any method in the annotated class
+     */
     @Pointcut("execution(* *.*(..))")
     protected void allMethods() {
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
@@ -1,0 +1,45 @@
+package org.opentestsystem.ap.imrt.common.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.opentestsystem.ap.imrt.common.service.OperationalEventService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Aspect
+@Configuration
+public class LoggingAspectConfiguration {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final OperationalEventService operationalEventService;
+
+    @Autowired
+    public LoggingAspectConfiguration(final OperationalEventService operationalEventService) {
+        this.operationalEventService = operationalEventService;
+    }
+
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController * )")
+    public void springRestControllers() {
+    }
+
+    @Pointcut("execution(* *.*(..))")
+    protected void allMethods() {
+    }
+
+    @Around("springRestControllers() && allMethods()")
+    public Object logAround(final ProceedingJoinPoint joinPoint) throws Throwable {
+        final long startTimeInMs = System.currentTimeMillis();
+        final Object result = joinPoint.proceed();
+
+        operationalEventService.serviceInfo(logger,
+                "Method signature: {}, args: {}, elapsed time (in ms): {}",
+                joinPoint.getSignature().toShortString(),
+                joinPoint.getArgs(),
+                System.currentTimeMillis() - startTimeInMs);
+
+        return result;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/config/LoggingAspectConfiguration.java
@@ -10,6 +10,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Create an {@link org.aspectj.lang.annotation.Aspect} that will record the following in a log file at INFO level:
+ * <p>
+ * -- The method signature (the name of the {@link org.springframework.stereotype.Controller}'s class and the method called)
+ * -- The arguments passed into the method
+ * -- How long the method call took in milliseconds
+ * <p>
+ * This aspect will bind to any classes that have the {@link org.springframework.web.bind.annotation.RestController}
+ * annotation.  All methods in the annotated class will be intercepted and logged.
+ */
 @Aspect
 @Configuration
 public class LoggingAspectConfiguration {
@@ -29,13 +39,23 @@ public class LoggingAspectConfiguration {
     protected void allMethods() {
     }
 
+    /**
+     * Log the method in progress, capturing the method name, the input arguments and how long the method took to get
+     * the result.
+     *
+     * @param joinPoint The {@link org.aspectj.lang.ProceedingJoinPoint} representing the method call that is being
+     *                  recorded.
+     * @return The result of the method call
+     * @throws java.lang.Throwable whenever an exception is encountered during the method call
+     */
     @Around("springRestControllers() && allMethods()")
     public Object logAround(final ProceedingJoinPoint joinPoint) throws Throwable {
         final long startTimeInMs = System.currentTimeMillis();
+
         final Object result = joinPoint.proceed();
 
         operationalEventService.serviceInfo(logger,
-                "Method signature: {}, args: {}, elapsed time (in ms): {}",
+                "Method signature: {}, input args: {}, elapsed time (in ms): {}",
                 joinPoint.getSignature().toShortString(),
                 joinPoint.getArgs(),
                 System.currentTimeMillis() - startTimeInMs);

--- a/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventService.java
@@ -18,7 +18,7 @@ public abstract class OperationalEventService {
      * Service related events, requiring action by Operations
      */
     protected enum ServiceEventType {
-        SERVICE_WARNING, SERVICE_ERROR
+        SERVICE_WARNING, SERVICE_ERROR, SERVICE_INFO
     }
 
     /**
@@ -103,6 +103,18 @@ public abstract class OperationalEventService {
      */
     public void serviceWarning(Logger logger, Throwable e, String format, Object... args) {
         serviceEvent(logger, ServiceEventType.SERVICE_WARNING, e, format, args);
+    }
+
+    /**
+     * Indicates an informational message that should be written to the log.
+     *
+     * @param logger Logger belonging to the calling class
+     * @param format The format string for the message. Uses the standard slf4j formatting scheme
+     *               of using {} as placeholders for arguments
+     * @param args A list of arguments, corresponding to the {} placeholders in the format string.
+     */
+    public void serviceInfo(Logger logger, String format, Object... args) {
+        serviceEvent(logger, ServiceEventType.SERVICE_INFO,null, format, args);
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImpl.java
@@ -45,10 +45,19 @@ public class OperationalEventServiceLoggerImpl extends OperationalEventService {
         String output = type + ": " + format;
         List<Object> allArgs = new ArrayList<>(Arrays.asList(args));
         allArgs.add(e);
-        if (ServiceEventType.SERVICE_ERROR == type) {
-            logger.error(output, allArgs.toArray());
-        } else {
-            logger.warn(output, allArgs.toArray());
+
+        switch (type) {
+            case SERVICE_ERROR:
+                logger.error(output, allArgs.toArray());
+                break;
+            case SERVICE_WARNING:
+                logger.warn(output, allArgs.toArray());
+                break;
+            case SERVICE_INFO:
+                logger.info(output, allArgs.toArray());
+                break;
+            default:
+                break;
         }
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/service/OperationalEventServiceLoggerImplTest.java
@@ -26,5 +26,7 @@ public class OperationalEventServiceLoggerImplTest {
 
         operationalEventService.serviceWarning(logger, null, "Test format {} {}", 1, 2);
         operationalEventService.serviceWarning(logger, new RuntimeException(), "test format {}", 3);
+
+        operationalEventService.serviceInfo(logger, "info test format{} {}", "foo", "bar");
     }
 }


### PR DESCRIPTION
[IMRT-383](https://jira.fairwaytech.com/browse/IMRT-383):  Add the following:

* A `serviceInfo` method to log `INFO`-level entries using the `OperationalEventService`
* A logging aspect that will log the following for any method in a class annotated with a `@RestController` annotation:
** The controller class name and method name
** The input argument(s)
** How long the method took to execute
* Log entries from the logging aspect will be recorded at the `INFO` level