### PR TITLE
IMRT-363:  Bugfix/attachment file type

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
@@ -39,11 +39,16 @@ public class Attachment extends BaseEntity {
      */
     private Attachment() {}
 
-    public Attachment(final BaseItem item, final String fileType, final String fileName, final Instant uploadedDate) {
+    public Attachment(final BaseItem item,
+                      final String fileType,
+                      final String fileName,
+                      final Instant uploadedDate,
+                      final String updatedBy) {
         this.item = item;
         this.fileType = fileType;
         this.fileName = fileName;
         this.uploadedDate = uploadedDate;
+        setUpdatedBy(updatedBy);
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -7,6 +7,7 @@ import org.opentestsystem.ap.common.model.Item;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -107,15 +108,15 @@ public abstract class BaseItem extends BaseEntity {
     private String translationRequired = EMPTY;
     private String translationProvided = EMPTY;
 
-    @OneToMany(mappedBy = "item")
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'asl'")
     private List<Attachment> aslAttachments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item")
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'braille'")
     private List<Attachment> brailleAttachments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item")
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'cc'")
     private List<Attachment> ccAttachments = new ArrayList<>();
     private Integer exposuresCount;

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -108,15 +108,15 @@ public abstract class BaseItem extends BaseEntity {
     private String translationProvided = EMPTY;
 
     @OneToMany(mappedBy = "item")
-    @Where(clause = "type = 'asl'")
+    @Where(clause = "file_type = 'asl'")
     private List<Attachment> aslAttachments = new ArrayList<>();
 
     @OneToMany(mappedBy = "item")
-    @Where(clause = "type = 'braille'")
+    @Where(clause = "file_type = 'braille'")
     private List<Attachment> brailleAttachments = new ArrayList<>();
 
     @OneToMany(mappedBy = "item")
-    @Where(clause = "type = 'cc'")
+    @Where(clause = "file_type = 'cc'")
     private List<Attachment> ccAttachments = new ArrayList<>();
     private Integer exposuresCount;
     private Integer formCount;

--- a/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
@@ -54,15 +54,20 @@ public class BaseItemRepositoryIntegrationTest {
         final Attachment aslAttachment = new Attachment(imrtItem,
                 AttachmentFileTypes.ASL,
                 "asl-filename",
-                Instant.now());
+                Instant.now(),
+                "me");
         final Attachment brailleAttachment = new Attachment(imrtItem,
                 AttachmentFileTypes.BRAILLE,
                 "braille-filename",
-                Instant.now());
+                Instant.now(),
+                "me");
+        brailleAttachment.setUpdatedBy("me");
         final Attachment ccAttachment = new Attachment(imrtItem,
                 AttachmentFileTypes.CC,
                 "cc-filename",
-                Instant.now());
+                Instant.now(),
+                "me");
+        ccAttachment.setUpdatedBy("me");
 
         imrtItem.setAslAttachments(Collections.singletonList(aslAttachment));
         imrtItem.setBrailleAttachments(Collections.singletonList(brailleAttachment));


### PR DESCRIPTION
I discovered a couple bugs while working with AP_IMRT_ItemIngest:

* The `BaseItem`'s accompanying `Attachment`s were not being persisted to the database
* The column name in the `@Where` annotation for the `Attachment` lists had an incorrect column name
* The `updatedBy` field was not being populated, even though the `Attachment` extends `BaseEntity`

Curiously, neither of these were exposed by the integration test.