### PR TITLE
Bugfix/imrt 439

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
@@ -58,4 +58,23 @@ public class Attachment extends BaseEntity {
     public void setUploadedDate(final Instant uploadedDate) {
         this.uploadedDate = uploadedDate;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Attachment)) return false;
+
+        final Attachment that = (Attachment) o;
+
+        return getAttachmentKey() != null
+                ? getAttachmentKey().equals(that.getAttachmentKey())
+                : that.getAttachmentKey() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getAttachmentKey() != null
+                ? getAttachmentKey().hashCode()
+                : 0;
+    }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/Attachment.java
@@ -20,8 +20,6 @@ public class Attachment extends BaseEntity {
     @EmbeddedId
     private AttachmentKey attachmentKey;
 
-    private String fileType;
-
     @Column(name = "uploaded_at")
     private Instant uploadedDate;
 
@@ -32,11 +30,9 @@ public class Attachment extends BaseEntity {
     }
 
     public Attachment(final AttachmentKey attachmentKey,
-                      final String fileType,
                       final Instant uploadedDate,
                       final String updatedBy) {
         this.attachmentKey = attachmentKey;
-        this.fileType = fileType;
         this.uploadedDate = uploadedDate;
         setUpdatedBy(updatedBy);
     }
@@ -50,17 +46,6 @@ public class Attachment extends BaseEntity {
 
     public void setAttachmentKey(final AttachmentKey attachmentKey) {
         this.attachmentKey = attachmentKey;
-    }
-
-    /**
-     * @return The type of {@link org.opentestsystem.ap.imrt.common.model.Attachment}
-     */
-    public String getFileType() {
-        return fileType;
-    }
-
-    public void setFileType(final String fileType) {
-        this.fileType = fileType;
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 public class AttachmentKey implements Serializable {
     private Integer itemKey;
     private String fileName;
+    private String fileType;
 
     /**
      * Constructor for frameworks
@@ -21,9 +22,10 @@ public class AttachmentKey implements Serializable {
     private AttachmentKey() {
     }
 
-    public AttachmentKey(final Integer itemKey, final String fileName) {
+    public AttachmentKey(final Integer itemKey, final String fileName, final String fileType) {
         this.itemKey = itemKey;
         this.fileName = fileName;
+        this.fileType = fileType;
     }
 
     /**
@@ -50,6 +52,17 @@ public class AttachmentKey implements Serializable {
         this.fileName = fileName;
     }
 
+    /**
+     * @return The type of {@link org.opentestsystem.ap.imrt.common.model.Attachment}
+     */
+    public String getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(final String fileType) {
+        this.fileType = fileType;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -57,14 +70,17 @@ public class AttachmentKey implements Serializable {
 
         final AttachmentKey that = (AttachmentKey) o;
 
-        if (!getItem().equals(that.getItem())) return false;
-        return getFileName().equals(that.getFileName());
+        if (itemKey != null ? !itemKey.equals(that.itemKey) : that.itemKey != null) return false;
+        if (getFileName() != null ? !getFileName().equals(that.getFileName()) : that.getFileName() != null)
+            return false;
+        return getFileType() != null ? getFileType().equals(that.getFileType()) : that.getFileType() == null;
     }
 
     @Override
     public int hashCode() {
-        int result = getItem().hashCode();
-        result = 31 * result + getFileName().hashCode();
+        int result = itemKey != null ? itemKey.hashCode() : 0;
+        result = 31 * result + (getFileName() != null ? getFileName().hashCode() : 0);
+        result = 31 * result + (getFileType() != null ? getFileType().hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
@@ -3,7 +3,6 @@ package org.opentestsystem.ap.imrt.common.model;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.persistence.Embeddable;
-import javax.persistence.ManyToOne;
 import java.io.Serializable;
 
 /**

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
 public class AttachmentKey implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_key", insertable = false, updatable = false, nullable = false)
-    private BaseItem itemKey;
+    private BaseItem item;
     private String fileName;
     private String fileType;
 
@@ -26,8 +26,8 @@ public class AttachmentKey implements Serializable {
     private AttachmentKey() {
     }
 
-    public AttachmentKey(final BaseItem itemKey, final String fileName, final String fileType) {
-        this.itemKey = itemKey;
+    public AttachmentKey(final BaseItem item, final String fileName, final String fileType) {
+        this.item = item;
         this.fileName = fileName;
         this.fileType = fileType;
     }
@@ -37,11 +37,11 @@ public class AttachmentKey implements Serializable {
      * {@link org.opentestsystem.ap.imrt.common.model.Attachment} is associated
      */
     public BaseItem getItem() {
-        return itemKey;
+        return item;
     }
 
     public void setItem(final BaseItem item) {
-        this.itemKey = item;
+        this.item = item;
     }
 
 
@@ -74,7 +74,7 @@ public class AttachmentKey implements Serializable {
 
         final AttachmentKey that = (AttachmentKey) o;
 
-        if (itemKey != null ? !itemKey.equals(that.itemKey) : that.itemKey != null) return false;
+        if (item != null ? !item.equals(that.item) : that.item != null) return false;
         if (getFileName() != null ? !getFileName().equals(that.getFileName()) : that.getFileName() != null)
             return false;
         return getFileType() != null ? getFileType().equals(that.getFileType()) : that.getFileType() == null;
@@ -82,7 +82,7 @@ public class AttachmentKey implements Serializable {
 
     @Override
     public int hashCode() {
-        int result = itemKey != null ? itemKey.hashCode() : 0;
+        int result = item != null ? item.hashCode() : 0;
         result = 31 * result + (getFileName() != null ? getFileName().hashCode() : 0);
         result = 31 * result + (getFileType() != null ? getFileType().hashCode() : 0);
         return result;

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/AttachmentKey.java
@@ -3,6 +3,9 @@ package org.opentestsystem.ap.imrt.common.model;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.io.Serializable;
 
 /**
@@ -11,7 +14,9 @@ import java.io.Serializable;
 @SuppressFBWarnings("SE_BAD_FIELD")
 @Embeddable
 public class AttachmentKey implements Serializable {
-    private Integer itemKey;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_key", insertable = false, updatable = false, nullable = false)
+    private BaseItem itemKey;
     private String fileName;
     private String fileType;
 
@@ -21,7 +26,7 @@ public class AttachmentKey implements Serializable {
     private AttachmentKey() {
     }
 
-    public AttachmentKey(final Integer itemKey, final String fileName, final String fileType) {
+    public AttachmentKey(final BaseItem itemKey, final String fileName, final String fileType) {
         this.itemKey = itemKey;
         this.fileName = fileName;
         this.fileType = fileType;
@@ -31,11 +36,11 @@ public class AttachmentKey implements Serializable {
      * @return The {@link org.opentestsystem.ap.imrt.common.model.BaseItem} to which this
      * {@link org.opentestsystem.ap.imrt.common.model.Attachment} is associated
      */
-    public Integer getItem() {
+    public BaseItem getItem() {
         return itemKey;
     }
 
-    public void setItem(final Integer item) {
+    public void setItem(final BaseItem item) {
         this.itemKey = item;
     }
 

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -24,7 +24,8 @@ import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
@@ -116,15 +117,15 @@ public abstract class BaseItem extends BaseEntity {
 
     @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'asl'")
-    private List<Attachment> aslAttachments = new ArrayList<>();
+    private Set<Attachment> aslAttachments = new HashSet<>();
 
     @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'braille'")
-    private List<Attachment> brailleAttachments = new ArrayList<>();
+    private Set<Attachment> brailleAttachments = new HashSet<>();
 
     @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
     @Where(clause = "file_type = 'cc'")
-    private List<Attachment> ccAttachments = new ArrayList<>();
+    private Set<Attachment> ccAttachments = new HashSet<>();
 
     @OneToMany(mappedBy = "item", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Collection<Form> forms;
@@ -591,33 +592,33 @@ public abstract class BaseItem extends BaseEntity {
     /**
      * @return A collection of ASL files that have been attached to this item
      */
-    public List<Attachment> getAslAttachments() {
+    public Set<Attachment> getAslAttachments() {
         return aslAttachments;
     }
 
-    public void setAslAttachments(final List<Attachment> aslAttachments) {
+    public void setAslAttachments(final Set<Attachment> aslAttachments) {
         this.aslAttachments = aslAttachments;
     }
 
     /**
      * @return A collection of braille files that have been attached to this item
      */
-    public List<Attachment> getBrailleAttachments() {
+    public Set<Attachment> getBrailleAttachments() {
         return brailleAttachments;
     }
 
-    public void setBrailleAttachments(final List<Attachment> brailleAttachments) {
+    public void setBrailleAttachments(final Set<Attachment> brailleAttachments) {
         this.brailleAttachments = brailleAttachments;
     }
 
     /**
      * @return A collection of close-caption files that have been attached to this item
      */
-    public List<Attachment> getCcAttachments() {
+    public Set<Attachment> getCcAttachments() {
         return ccAttachments;
     }
 
-    public void setCcAttachments(final List<Attachment> ccAttachments) {
+    public void setCcAttachments(final Set<Attachment> ccAttachments) {
         this.ccAttachments = ccAttachments;
     }
 

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -115,15 +115,15 @@ public abstract class BaseItem extends BaseEntity {
     private String writingPurpose = EMPTY;
     private String performanceTask = EMPTY;
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'asl'")
     private Set<Attachment> aslAttachments = new HashSet<>();
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'braille'")
     private Set<Attachment> brailleAttachments = new HashSet<>();
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'cc'")
     private Set<Attachment> ccAttachments = new HashSet<>();
 

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -22,7 +22,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -115,15 +114,15 @@ public abstract class BaseItem extends BaseEntity {
     private String writingPurpose = EMPTY;
     private String performanceTask = EMPTY;
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "attachmentKey.item", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'asl'")
     private Set<Attachment> aslAttachments = new HashSet<>();
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "attachmentKey.item", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'braille'")
     private Set<Attachment> brailleAttachments = new HashSet<>();
 
-    @OneToMany(mappedBy = "attachmentKey.itemKey", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "attachmentKey.item", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Where(clause = "file_type = 'cc'")
     private Set<Attachment> ccAttachments = new HashSet<>();
 

--- a/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
@@ -9,7 +9,9 @@ import org.opentestsystem.ap.imrt.common.model.Form;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @SuppressWarnings("unchecked")
 public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseItem> extends BaseEntityBuilder<BaseItem> {
@@ -56,9 +58,9 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
     private String translationProvided = "no";
     private String performanceTask = "Yes";
     private String writingPurpose = "Reading";
-    private List<Attachment> aslAttachments = new ArrayList<>();
-    private List<Attachment> brailleAttachments = new ArrayList<>();
-    private List<Attachment> ccAttachments = new ArrayList<>();
+    private Set<Attachment> aslAttachments = new HashSet<>();
+    private Set<Attachment> brailleAttachments = new HashSet<>();
+    private Set<Attachment> ccAttachments = new HashSet<>();
 
     private Integer exposuresCount = 100;
     private Integer formCount = 4;
@@ -274,17 +276,17 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         return (B) this;
     }
 
-    public B withAslAttachments(final List<Attachment> aslAttachments) {
+    public B withAslAttachments(final Set<Attachment> aslAttachments) {
         this.aslAttachments = aslAttachments;
         return (B) this;
     }
 
-    public B withBrailleAttachments(final List<Attachment> brailleAttachments) {
+    public B withBrailleAttachments(final Set<Attachment> brailleAttachments) {
         this.brailleAttachments = brailleAttachments;
         return (B) this;
     }
 
-    public B withCcAttachments(final List<Attachment> ccAttachments) {
+    public B withCcAttachments(final Set<Attachment> ccAttachments) {
         this.ccAttachments = ccAttachments;
         return (B) this;
     }

--- a/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
@@ -7,10 +7,8 @@ import org.opentestsystem.ap.imrt.common.model.BaseItem;
 import org.opentestsystem.ap.imrt.common.model.Form;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @SuppressWarnings("unchecked")
@@ -290,7 +288,7 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         this.ccAttachments = ccAttachments;
         return (B) this;
     }
-    
+
     public B withItemDifficultyQuintile(final Integer itemDifficultyQuintile) {
         this.itemDifficultyQuintile = itemDifficultyQuintile;
         return (B) this;

--- a/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
@@ -51,14 +51,14 @@ public class BaseItemRepositoryIntegrationTest {
                 .withCcProvided("yes")
                 .build();
 
-        final Attachment aslAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "asl-filename", AttachmentFileTypes.ASL),
+        final Attachment aslAttachment = new Attachment(new AttachmentKey(imrtItem, "asl-filename", AttachmentFileTypes.ASL),
                 Instant.now(),
                 "me");
-        final Attachment brailleAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "braille-filename", AttachmentFileTypes.BRAILLE),
+        final Attachment brailleAttachment = new Attachment(new AttachmentKey(imrtItem, "braille-filename", AttachmentFileTypes.BRAILLE),
                 Instant.now(),
                 "me");
         brailleAttachment.setUpdatedBy("me");
-        final Attachment ccAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "cc-filename", AttachmentFileTypes.CC),
+        final Attachment ccAttachment = new Attachment(new AttachmentKey(imrtItem, "cc-filename", AttachmentFileTypes.CC),
                 Instant.now(),
                 "me");
         ccAttachment.setUpdatedBy("me");

--- a/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
@@ -50,17 +50,14 @@ public class BaseItemRepositoryIntegrationTest {
                 .withCcProvided("yes")
                 .build();
 
-        final Attachment aslAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "asl-filename"),
-                AttachmentFileTypes.ASL,
+        final Attachment aslAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "asl-filename", AttachmentFileTypes.ASL),
                 Instant.now(),
                 "me");
-        final Attachment brailleAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "braille-filename"),
-                AttachmentFileTypes.BRAILLE,
+        final Attachment brailleAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "braille-filename", AttachmentFileTypes.BRAILLE),
                 Instant.now(),
                 "me");
         brailleAttachment.setUpdatedBy("me");
-        final Attachment ccAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "cc-filename"),
-                AttachmentFileTypes.CC,
+        final Attachment ccAttachment = new Attachment(new AttachmentKey(imrtItem.getKey(), "cc-filename", AttachmentFileTypes.CC),
                 Instant.now(),
                 "me");
         ccAttachment.setUpdatedBy("me");
@@ -74,13 +71,13 @@ public class BaseItemRepositoryIntegrationTest {
         final BaseItem savedItem = baseItemRepository.findById(imrtItem.getId());
 
         assertThat(savedItem.getAslAttachments()).hasSize(1);
-        assertThat(savedItem.getAslAttachments().get(0).getFileType()).isEqualTo("asl");
+        assertThat(savedItem.getAslAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("asl");
 
         assertThat(savedItem.getBrailleAttachments()).hasSize(1);
-        assertThat(savedItem.getBrailleAttachments().get(0).getFileType()).isEqualTo("braille");
+        assertThat(savedItem.getBrailleAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("braille");
 
         assertThat(savedItem.getCcAttachments()).hasSize(1);
-        assertThat(savedItem.getCcAttachments().get(0).getFileType()).isEqualTo("cc");
+        assertThat(savedItem.getCcAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("cc");
     }
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/repository/BaseItemRepositoryIntegrationTest.java
@@ -63,22 +63,22 @@ public class BaseItemRepositoryIntegrationTest {
                 "me");
         ccAttachment.setUpdatedBy("me");
 
-        imrtItem.setAslAttachments(Collections.singletonList(aslAttachment));
-        imrtItem.setBrailleAttachments(Collections.singletonList(brailleAttachment));
-        imrtItem.setCcAttachments(Collections.singletonList(ccAttachment));
+        imrtItem.setAslAttachments(Collections.singleton(aslAttachment));
+        imrtItem.setBrailleAttachments(Collections.singleton(brailleAttachment));
+        imrtItem.setCcAttachments(Collections.singleton(ccAttachment));
 
         assertThat(imrtItem).isEqualTo(imrtItemRepository.save(imrtItem));
 
         final BaseItem savedItem = baseItemRepository.findById(imrtItem.getId());
 
         assertThat(savedItem.getAslAttachments()).hasSize(1);
-        assertThat(savedItem.getAslAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("asl");
+        assertThat(savedItem.getAslAttachments().stream().findFirst().get().getAttachmentKey().getFileType()).isEqualTo("asl");
 
         assertThat(savedItem.getBrailleAttachments()).hasSize(1);
-        assertThat(savedItem.getBrailleAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("braille");
+        assertThat(savedItem.getBrailleAttachments().stream().findFirst().get().getAttachmentKey().getFileType()).isEqualTo("braille");
 
         assertThat(savedItem.getCcAttachments()).hasSize(1);
-        assertThat(savedItem.getCcAttachments().get(0).getAttachmentKey().getFileType()).isEqualTo("cc");
+        assertThat(savedItem.getCcAttachments().stream().findFirst().get().getAttachmentKey().getFileType()).isEqualTo("cc");
     }
 
     @Test


### PR DESCRIPTION
[IMRT-439](https://jira.fairwaytech.com/browse/IMRT-439):
* Change `List<Attachment>` to `Set<Attachment>` to eliminate duplicate records
* Make `Attachment#equals` and `Attachment#getHashCode` null-safe
* Update `AttachmentKey`:
  * Change `itemKey` from `Integer` to `BaseItem`
  * Add `@ManyToOne` annotation and apply fetch type & `@JoinColumn` mapping to prevent "infinite loop" between `BaseItem` and `Attachment` relationship