### PR TITLE
Feature/iat 2049

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ configurations {
 dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
-    compile 'org.opentestsystem.ap:ap-common:0.4.17'
+    compile 'org.opentestsystem.ap:ap-common:0.4.20'
     compile 'org.springframework.boot:spring-boot-starter-log4j2'
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
     compile 'org.postgresql:postgresql:42.2.1'

--- a/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/common/model/BaseItem.java
@@ -135,6 +135,11 @@ public abstract class BaseItem extends BaseEntity {
     private int englishPassagesCount = 0;
     private int spanishPassagesCount = 0;
 
+    private int severeValidationResultCount = 0;
+    private int degradedValidationResultCount = 0;
+    private int tolerableValidationResultCount = 0;
+    private int benignValidationResultCount = 0;
+
     /**
      * @return the unique key for an object
      */
@@ -813,5 +818,49 @@ public abstract class BaseItem extends BaseEntity {
 
     public void setSpanishPassagesCount(final int spanishPassagesCount) {
         this.spanishPassagesCount = spanishPassagesCount;
+    }
+
+    /**
+     * @return The number of validation results with a severity of "Severe"
+     */
+    public int getSevereValidationResultCount() {
+        return severeValidationResultCount;
+    }
+
+    public void setSevereValidationResultCount(final int severeValidationResultCount) {
+        this.severeValidationResultCount = severeValidationResultCount;
+    }
+
+    /**
+     * @return The number of validation results with a severity of "Degraded"
+     */
+    public int getDegradedValidationResultCount() {
+        return degradedValidationResultCount;
+    }
+
+    public void setDegradedValidationResultCount(final int degradedValidationResultCount) {
+        this.degradedValidationResultCount = degradedValidationResultCount;
+    }
+
+    /**
+     * @return The number of validation results with a severity of "Tolerable"
+     */
+    public int getTolerableValidationResultCount() {
+        return tolerableValidationResultCount;
+    }
+
+    public void setTolerableValidationResultCount(final int tolerableValidationResultCount) {
+        this.tolerableValidationResultCount = tolerableValidationResultCount;
+    }
+
+    /**
+     * @return The number of validation results with a severity of "Benign"
+     */
+    public int getBenignValidationResultCount() {
+        return benignValidationResultCount;
+    }
+
+    public void setBenignValidationResultCount(final int benignValidationResultCount) {
+        this.benignValidationResultCount = benignValidationResultCount;
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/common/builder/BaseItemBuilder.java
@@ -76,6 +76,11 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
     private Instant englishContentLastUpdatedAt = Instant.now();
     private Instant spanishContentLastUpdatedAt = Instant.now();
 
+    private int severeValidationResultCount = 0;
+    private int degradedValidationResultCount = 0;
+    private int tolerableValidationResultCount = 0;
+    private int benignValidationResultCount = 0;
+
     public B withKey(Integer key) {
         this.key = key;
         return (B) this;
@@ -377,6 +382,26 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         return (B) this;
     }
 
+    public B withSevereValidationResultsCount(final int severeValidationResultCount) {
+        this.severeValidationResultCount = severeValidationResultCount;
+        return (B) this;
+    }
+
+    public B withDegradedValidationResultsCount(final int degradedValidationResultCount) {
+        this.degradedValidationResultCount = degradedValidationResultCount;
+        return (B) this;
+    }
+
+    public B withTolerableValidationResultsCount(final int tolerableValidationResultCount) {
+        this.tolerableValidationResultCount = tolerableValidationResultCount;
+        return (B) this;
+    }
+
+    public B withBenignValidationResultsCount(final int benignValidationResultCount) {
+        this.benignValidationResultCount = benignValidationResultCount;
+        return (B) this;
+    }
+
     T build(T item) {
         super.build(item);
         item.setKey(key);
@@ -439,6 +464,10 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         item.setClosedCaptioningUploadedPriorToLastContentUpdate(closedCaptioningUploadedPriorToLastContentUpdate);
         item.setEnglishPassagesCount(englishPassagesCount);
         item.setSpanishPassagesCount(spanishPassagesCount);
+        item.setSevereValidationResultCount(severeValidationResultCount);
+        item.setDegradedValidationResultCount(degradedValidationResultCount);
+        item.setTolerableValidationResultCount(tolerableValidationResultCount);
+        item.setBenignValidationResultCount(benignValidationResultCount);
         return item;
     }
 }


### PR DESCRIPTION
[IAT-2049](https://jira.fairwaytech.com/browse/IAT-2049):  Add fields for validation results count fields.

### Additional Notes
After testing a query that would get the counts from the `validation_result` table for each of the severity levels, I decided it would be better to store the counts whenever the item is submitted to the validation service.